### PR TITLE
fix: broken dockerfile, outdated rust and ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:oracular as rustbuild
+FROM buildpack-deps:jammy as rustbuild
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -51,7 +51,7 @@ RUN yarn install
 RUN yarn run build
 
 # build final image
-FROM ubuntu:oracular
+FROM ubuntu:jammy
 
 # install dependencies
 RUN apt update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:jammy as rustbuild
+FROM buildpack-deps:plucky as rustbuild
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.63.0
+    RUST_VERSION=1.86.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
@@ -43,7 +43,7 @@ WORKDIR /usr/src/pff-tools/pff-cli
 RUN cargo install --path .
 
 # build web app
-FROM node:18 as nodebuild
+FROM node:23-slim as nodebuild
 WORKDIR /usr/src/pff-tools
 COPY . .
 WORKDIR /usr/src/pff-tools/pff-web
@@ -51,7 +51,7 @@ RUN yarn install
 RUN yarn run build
 
 # build final image
-FROM ubuntu:jammy
+FROM ubuntu:plucky
 
 # install dependencies
 RUN apt update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:plucky as rustbuild
+FROM buildpack-deps:oracular as rustbuild
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -51,7 +51,7 @@ RUN yarn install
 RUN yarn run build
 
 # build final image
-FROM ubuntu:plucky
+FROM ubuntu:oracular
 
 # install dependencies
 RUN apt update && \


### PR DESCRIPTION
A few of the dependencies in the Dockerfile require a higher version of rust. This change bumps the version of rust so the Dockerfile builds. I also bumped the node image. Here were some of the errors I found:

~~~
72.83 error: failed to compile `pff-web v0.1.0 (/usr/src/pff-tools/pff-web)`, intermediate artifacts can be found at `/usr/src/pff-tools/target` 72.83 
72.83 Caused by:
72.83   package `regex-syntax v0.8.5` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.63.0
~~~

~~~
81.32 error: failed to compile `pff-web v0.1.0 (/usr/src/pff-tools/pff-web)`, intermediate artifacts can be found at `/usr/src/pff-tools/target` 81.32 
81.32 Caused by:
81.32   package `icu_normalizer_data v1.5.1` cannot be built because it requires rustc 1.67 or newer, while the currently active rustc version is 1.65.0
81.32   Either upgrade to rustc 1.67 or newer, or use
81.32   cargo update -p icu_normalizer_data@1.5.1 --precise ver
81.32   where `ver` is the latest version of `icu_normalizer_data` supporting rustc 1.65.0
~~~

~~~
72.84 error: failed to compile `pff-web v0.1.0 (/usr/src/pff-tools/pff-web)`, intermediate artifacts can be found at `/usr/src/pff-tools/target` 72.84 
72.84 Caused by:
72.84   package `yoke v0.7.5` cannot be built because it requires rustc 1.71.1 or newer, while the currently active rustc version is 1.67.0
72.84   Either upgrade to rustc 1.71.1 or newer, or use
72.84   cargo update -p yoke@0.7.5 --precise ver
72.84   where `ver` is the latest version of `yoke` supporting rustc 1.67.0
~~~

## Note

I tried bumping ubuntu, but was getting build errors looking like:

<details>

```bash
    25.82 Caused by:
    25.82   process didn't exit successfully: `/usr/src/pff-tools/target/release/build/pff-sys-fea502d97a24d728/build-script-build` (exit status: 101)
    25.82   --- stdout
    25.82   cargo:rerun-if-env-changed=LIBPFF_NO_PKG_CONFIG
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG
    25.82   cargo:rerun-if-env-changed=LIBPFF_STATIC
    25.82   cargo:rerun-if-env-changed=LIBPFF_DYNAMIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_PATH
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
    25.82   cargo:rerun-if-env-changed=SYSROOT
    25.82   cargo:rerun-if-env-changed=LIBPFF_STATIC
    25.82   cargo:rerun-if-env-changed=LIBPFF_DYNAMIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
    25.82   cargo:rustc-link-search=native=/usr/local/lib
    25.82   cargo:rustc-link-lib=pff
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG
    25.82   cargo:rerun-if-env-changed=LIBPFF_STATIC
    25.82   cargo:rerun-if-env-changed=LIBPFF_DYNAMIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_PATH
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-unknown-linux-gnu
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu
    25.82   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
    25.82   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
    25.82   cargo:rerun-if-changed=wrapper.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/codepage.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/types.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/sys/types.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/features-time64.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wordsize.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/timesize.h
    25.82   cargo:rerun-if-changed=/usr/include/stdc-predef.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/sys/cdefs.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wordsize.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/long-double.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/gnu/stubs.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wordsize.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/gnu/stubs-lp64.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wordsize.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/timesize.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/typesizes.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/time64.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/clock_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/clockid_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/time_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/timer_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/stddef.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stddef_size_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/stdint-intn.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/endian.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/endian.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/endianness.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/byteswap.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/uintn-identity.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/sys/select.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/select.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/sigset_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__sigset_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/time_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/struct_timeval.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/struct_timespec.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/endian.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/time_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/pthreadtypes.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/thread-shared-types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/pthreadtypes-arch.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/endian.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/atomic_wide_counter.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/struct_mutex.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/struct_rwlock.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/inttypes.h
    25.82   cargo:rerun-if-changed=/usr/include/inttypes.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/stdint.h
    25.82   cargo:rerun-if-changed=/usr/include/stdint.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/libc-header-start.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wchar.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wordsize.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/stdint-intn.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/stdint-uintn.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/stdint-least.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/wchar.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/libc-header-start.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/floatn.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/long-double.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/floatn-common.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/long-double.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/stddef.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stddef_size_t.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stddef_wchar_t.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stddef_null.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/stdarg.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stdarg___gnuc_va_list.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/wchar.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/wint_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/mbstate_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__mbstate_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__FILE.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/FILE.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/locale_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__locale_t.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/definitions.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/types.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/error.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/types.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/extern.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/features.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/mapi.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/types.h
    25.82   cargo:rerun-if-changed=/usr/local/include/libpff/types.h
    25.82   cargo:rerun-if-changed=/usr/include/stdio.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/libc-header-start.h
    25.82   cargo:rerun-if-changed=/usr/include/features.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/stddef.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stddef_size_t.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stddef_null.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/stdarg.h
    25.82   cargo:rerun-if-changed=/usr/lib/llvm-19/lib/clang/19/include/__stdarg___gnuc_va_list.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__fpos_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__mbstate_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__fpos64_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__mbstate_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/__FILE.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/FILE.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/struct_FILE.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types/cookie_io_functions_t.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/types.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/stdio_lim.h
    25.82   cargo:rerun-if-changed=/usr/include/aarch64-linux-gnu/bits/floatn.h
    25.82 
    25.82   --- stderr
    25.82 
    25.82   thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.60.1/src/ir/context.rs:861:9:
    25.82   "__atomic_wide_counter_struct_(unnamed_at_/usr/include/aarch64-linux-gnu/bits/atomic_wide_counter_h_28_3)" is not a valid Ident
    25.82   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    25.82 warning: build failed, waiting for other jobs to finish...
    28.53 error: failed to compile `pff-web v0.1.0 (/usr/src/pff-tools/pff-web)`, intermediate artifacts can be found at `/usr/src/pff-tools/target`.
    28.53 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```
</details>